### PR TITLE
fix path to add MongoDB yum repo

### DIFF
--- a/source/platforms/amazon-ec2.txt
+++ b/source/platforms/amazon-ec2.txt
@@ -106,7 +106,7 @@ After login, update installed packages, add the MongoDB yum repo, and install Mo
     name=MongoDB Repository
     baseurl=http://downloads-distro.mongodb.org/repo/redhat/os/x86_64
     gpgcheck=0
-    enabled=1" | sudo tee -a /etc/yum.repos.d/mongodb.repo
+    enabled=1" | sudo tee -a /etc/yum/repos.d/mongodb.repo
 
     $ sudo yum install -y mongodb-org-server mongodb-org-shell mongodb-org-tools
 


### PR DESCRIPTION
While trying to set up MongoDB with my AWS EC2 instance, I found this error. On the current documentation, it states to add a MongoDB yum repo with the following commands:

<img width="774" alt="screen shot 2016-02-25 at 8 07 57 pm" src="https://cloud.githubusercontent.com/assets/9559638/13341168/e5746874-dbfb-11e5-8a6f-e431fdfc2f0a.png">

However, that path is not '/etc/yum.repos.d/mongodb.repo. It's actually the following:

![screenshot 2016-02-24 21 24 20](https://cloud.githubusercontent.com/assets/9559638/13341176/ff36702c-dbfb-11e5-8343-274811df0d56.png)

I fixed the path on the docs so users don't run into errors of this path not existing while trying to run the commands above.